### PR TITLE
added possibility to link between help texts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 
 buildscript {
-    ext.cubaVersion = '6.8.6'
+    ext.cubaVersion = '6.8.8'
     repositories {
         mavenLocal()
         maven {

--- a/modules/web/src/de/balvi/cuba/helpsystem/web-screens.xml
+++ b/modules/web/src/de/balvi/cuba/helpsystem/web-screens.xml
@@ -11,8 +11,12 @@
             template="de/balvi/cuba/helpsystem/web/helpcontext/help-context-edit.xml"/>
     <screen id="dbchs$Helptext.browse"
             template="de/balvi/cuba/helpsystem/web/helptext/helptext-browse.xml"/>
+    <screen id="dbchs$Helptext.lookup"
+            template="de/balvi/cuba/helpsystem/web/helptext/helptext-lookup.xml"/>
     <screen id="dbchs$Helptext.edit"
             template="de/balvi/cuba/helpsystem/web/helptext/helptext-edit.xml"/>
     <screen id="dbchs$Helptext.show"
             template="de/balvi/cuba/helpsystem/web/helptext/helptext-show.xml"/>
+    <screen id="dbchs$Helptext.showSingle"
+            template="de/balvi/cuba/helpsystem/web/helptext/helptext-show-single.xml"/>
 </screen-config>

--- a/modules/web/src/de/balvi/cuba/helpsystem/web/helptext/AddHelptextLinkHandler.groovy
+++ b/modules/web/src/de/balvi/cuba/helpsystem/web/helptext/AddHelptextLinkHandler.groovy
@@ -14,7 +14,7 @@ class AddHelptextLinkHandler implements Window.Lookup.Handler {
     }
 
     String getValueForTarget(Collection items) {
-        "${target.getValue()} ${createLinkForHelptext(items[0] as Helptext)}"
+        "${target.value} ${createLinkForHelptext(items[0] as Helptext)}"
     }
 
     String createLinkForHelptext(Helptext helptext) {

--- a/modules/web/src/de/balvi/cuba/helpsystem/web/helptext/AddHelptextLinkHandler.groovy
+++ b/modules/web/src/de/balvi/cuba/helpsystem/web/helptext/AddHelptextLinkHandler.groovy
@@ -1,0 +1,23 @@
+package de.balvi.cuba.helpsystem.web.helptext
+
+import com.haulmont.cuba.gui.components.Component
+import com.haulmont.cuba.gui.components.Window
+import de.balvi.cuba.helpsystem.entity.Helptext
+
+class AddHelptextLinkHandler implements Window.Lookup.Handler {
+
+    Component.HasValue target
+
+    @Override
+    void handleLookup(Collection items) {
+        target.setValue(getValueForTarget(items))
+    }
+
+    String getValueForTarget(Collection items) {
+        "${target.getValue()} ${createLinkForHelptext(items[0] as Helptext)}"
+    }
+
+    String createLinkForHelptext(Helptext helptext) {
+        '<a href="open?screen=dbchs$Helptext.showSingle&amp;item=dbchs$Helptext-' + helptext.id + '">' + helptext.category.name + '</a>'
+    }
+}

--- a/modules/web/src/de/balvi/cuba/helpsystem/web/helptext/HelptextEdit.groovy
+++ b/modules/web/src/de/balvi/cuba/helpsystem/web/helptext/HelptextEdit.groovy
@@ -1,8 +1,25 @@
 package de.balvi.cuba.helpsystem.web.helptext
 
+import com.haulmont.cuba.gui.WindowManager
 import com.haulmont.cuba.gui.components.AbstractEditor
+import com.haulmont.cuba.gui.components.RichTextArea
 import de.balvi.cuba.helpsystem.entity.Helptext
+
+import javax.inject.Inject
 
 class HelptextEdit extends AbstractEditor<Helptext> {
 
+
+    @Inject
+    RichTextArea textTextArea
+
+    @Override
+    void init(Map<String, Object> params) {
+        super.init(params)
+
+    }
+
+    void addHelptextLink() {
+        openLookup(Helptext, new AddHelptextLinkHandler(target: textTextArea), WindowManager.OpenType.DIALOG)
+    }
 }

--- a/modules/web/src/de/balvi/cuba/helpsystem/web/helptext/HelptextEdit.groovy
+++ b/modules/web/src/de/balvi/cuba/helpsystem/web/helptext/HelptextEdit.groovy
@@ -13,12 +13,6 @@ class HelptextEdit extends AbstractEditor<Helptext> {
     @Inject
     RichTextArea textTextArea
 
-    @Override
-    void init(Map<String, Object> params) {
-        super.init(params)
-
-    }
-
     void addHelptextLink() {
         openLookup(Helptext, new AddHelptextLinkHandler(target: textTextArea), WindowManager.OpenType.DIALOG)
     }

--- a/modules/web/src/de/balvi/cuba/helpsystem/web/helptext/HelptextLookup.groovy
+++ b/modules/web/src/de/balvi/cuba/helpsystem/web/helptext/HelptextLookup.groovy
@@ -1,0 +1,13 @@
+package de.balvi.cuba.helpsystem.web.helptext
+
+import com.haulmont.cuba.gui.components.AbstractLookup
+import com.haulmont.cuba.gui.components.Table
+import com.haulmont.cuba.gui.components.actions.CreateAction
+import com.haulmont.cuba.gui.components.actions.EditAction
+import de.balvi.cuba.helpsystem.entity.Helptext
+
+import javax.inject.Inject
+
+class HelptextLookup extends AbstractLookup {
+
+}

--- a/modules/web/src/de/balvi/cuba/helpsystem/web/helptext/HelptextLookup.groovy
+++ b/modules/web/src/de/balvi/cuba/helpsystem/web/helptext/HelptextLookup.groovy
@@ -1,12 +1,6 @@
 package de.balvi.cuba.helpsystem.web.helptext
 
 import com.haulmont.cuba.gui.components.AbstractLookup
-import com.haulmont.cuba.gui.components.Table
-import com.haulmont.cuba.gui.components.actions.CreateAction
-import com.haulmont.cuba.gui.components.actions.EditAction
-import de.balvi.cuba.helpsystem.entity.Helptext
-
-import javax.inject.Inject
 
 class HelptextLookup extends AbstractLookup {
 

--- a/modules/web/src/de/balvi/cuba/helpsystem/web/helptext/HelptextShowSingle.groovy
+++ b/modules/web/src/de/balvi/cuba/helpsystem/web/helptext/HelptextShowSingle.groovy
@@ -1,0 +1,12 @@
+package de.balvi.cuba.helpsystem.web.helptext
+
+import com.haulmont.cuba.gui.components.AbstractEditor
+import de.balvi.cuba.helpsystem.entity.Helptext
+
+class HelptextShowSingle extends AbstractEditor<Helptext> {
+
+    @Override
+    protected void postInit() {
+        caption = formatMessage('showCaption',item.category.name)
+    }
+}

--- a/modules/web/src/de/balvi/cuba/helpsystem/web/helptext/helptext-edit.xml
+++ b/modules/web/src/de/balvi/cuba/helpsystem/web/helptext/helptext-edit.xml
@@ -17,19 +17,31 @@
             </query>
         </collectionDatasource>
     </dsContext>
+    <actions>
+        <action id="addHelptextLink"
+                caption="msg://addHelptextLink"
+                invoke="addHelptextLink"
+                icon="font-icon:EXTERNAL_LINK"
+        />
+    </actions>
     <dialogMode height="600"
                 resizable="true"
                 width="800"/>
     <layout expand="textTextArea"
             spacing="true">
-        <fieldGroup id="fieldGroup"
-                    datasource="helptextDs">
-            <column width="400px">
-                <field optionsDatasource="categoriesDs"
-                       property="category"/>
-            </column>
-        </fieldGroup>
-
+        <hbox id="headerBox"
+              width="100%">
+            <fieldGroup id="fieldGroup"
+                        datasource="helptextDs">
+                <column width="250px">
+                    <field optionsDatasource="categoriesDs"
+                           property="category"/>
+                </column>
+            </fieldGroup>
+            <button id="addHelptextLinkBtn"
+                    align="TOP_RIGHT"
+                    action="addHelptextLink"/>
+        </hbox>
         <richTextArea id="textTextArea"
                       datasource="helptextDs"
                       property="text"

--- a/modules/web/src/de/balvi/cuba/helpsystem/web/helptext/helptext-lookup.xml
+++ b/modules/web/src/de/balvi/cuba/helpsystem/web/helptext/helptext-lookup.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <window xmlns="http://schemas.haulmont.com/cuba/window.xsd"
         caption="msg://browseCaption"
-        class="de.balvi.cuba.helpsystem.web.helptext.HelptextBrowse"
+        class="de.balvi.cuba.helpsystem.web.helptext.HelptextLookup"
         focusComponent="helptextsTable"
         lookupComponent="helptextsTable"
         messagesPack="de.balvi.cuba.helpsystem.web.helptext">
@@ -10,7 +10,7 @@
                          class="de.balvi.cuba.helpsystem.entity.Helptext"
                          view="helptext-with-category-view">
             <query>
-                <![CDATA[select e from dbchs$Helptext e where e.helpContext is null]]>
+                <![CDATA[select e from dbchs$Helptext e]]>
             </query>
         </collectionDatasource>
     </dsContext>
@@ -25,26 +25,14 @@
         </filter>
         <table id="helptextsTable"
                     width="100%">
-            <actions>
-                <action id="create"/>
-                <action id="edit"/>
-                <action id="remove"/>
-            </actions>
             <columns>
+                <column id="helpContext.screenId"/>
+                <column id="helpContext.componentId"/>
                 <column id="category"/>
                 <column id="text" maxTextLength="30"/>
             </columns>
             <rows datasource="helptextsDs"/>
             <rowsCount/>
-            <buttonsPanel id="buttonsPanel"
-                          alwaysVisible="true">
-                <button id="createBtn"
-                        action="helptextsTable.create"/>
-                <button id="editBtn"
-                        action="helptextsTable.edit"/>
-                <button id="removeBtn"
-                        action="helptextsTable.remove"/>
-            </buttonsPanel>
         </table>
     </layout>
 </window>

--- a/modules/web/src/de/balvi/cuba/helpsystem/web/helptext/helptext-show-single.xml
+++ b/modules/web/src/de/balvi/cuba/helpsystem/web/helptext/helptext-show-single.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<window xmlns="http://schemas.haulmont.com/cuba/window.xsd"
+        class="de.balvi.cuba.helpsystem.web.helptext.HelptextShowSingle"
+        datasource="helptextDs"
+        messagesPack="de.balvi.cuba.helpsystem.web.helptext">
+    <dsContext>
+        <datasource id="helptextDs"
+                    class="de.balvi.cuba.helpsystem.entity.Helptext"
+                    view="helptext-with-category-view"/>
+    </dsContext>
+    <dialogMode height="600"
+                resizable="true"
+                width="800"/>
+    <layout expand="helptextContent"
+            spacing="true">
+        <label id="helptextContent"
+               datasource="helptextDs"
+               property="text"
+               width="100%"
+               htmlEnabled="true"
+        />
+    </layout>
+</window>

--- a/modules/web/src/de/balvi/cuba/helpsystem/web/helptext/messages.properties
+++ b/modules/web/src/de/balvi/cuba/helpsystem/web/helptext/messages.properties
@@ -3,3 +3,4 @@ editorCaption = Helptext editor
 
 showCaption = Help: %s
 defaultShowCaption = Help
+addHelptextLink=Add Helptext link

--- a/modules/web/src/de/balvi/cuba/helpsystem/web/helptext/messages_de.properties
+++ b/modules/web/src/de/balvi/cuba/helpsystem/web/helptext/messages_de.properties
@@ -2,3 +2,5 @@ browseCaption = Hilfetexte Liste
 editorCaption = Hilfetext bearbeiten
 showCaption = Hilfe: %s
 defaultShowCaption = Hilfe
+
+addHelptextLink=Hilfetext Link hinzufügen

--- a/modules/web/test/de/balvi/cuba/helpsystem/web/helptext/AddHelptextLinkHandlerSpec.groovy
+++ b/modules/web/test/de/balvi/cuba/helpsystem/web/helptext/AddHelptextLinkHandlerSpec.groovy
@@ -1,0 +1,29 @@
+package de.balvi.cuba.helpsystem.web.helptext
+
+import com.haulmont.cuba.gui.components.Component
+import de.balvi.cuba.helpsystem.entity.Helptext
+import de.balvi.cuba.helpsystem.entity.HelptextCategory
+import spock.lang.Specification
+
+class AddHelptextLinkHandlerSpec extends Specification {
+    AddHelptextLinkHandler sut
+
+    Component.HasValue target = Mock(Component.HasValue)
+
+    def setup() {
+        sut = new AddHelptextLinkHandler(target: target)
+    }
+
+    def "handleLookup adds a link to the target value"() {
+
+        given:
+        def helptextId = UUID.randomUUID()
+        def helptextCategoryName = "my-category"
+        def helptext = new Helptext(id: helptextId, category: new HelptextCategory(name: helptextCategoryName))
+
+        when:
+        sut.handleLookup([helptext])
+        then:
+        1 * target.setValue({ it.contains(helptextId.toString()) && it.contains(helptextCategoryName)})
+    }
+}


### PR DESCRIPTION
Hi,

this PR adds the ability to link from one help text to another. I used CUBAs existing LinkHandler for that purpose. Therefore it will open another Tab when a Link is followed. 

### Example usage
![help-text-links-demo](https://user-images.githubusercontent.com/817400/40572779-dc6241de-60b5-11e8-94c3-9c75e16b3bdc.gif)

### Changes
* add a screen for displaying a single helptext
* add a button in the editor to add a Helptext Link to the helptext
* added an explicit lookup screen for picking a helptext to show context dependend as well as context independent helptexts.
* small screen layout adjustments
* updated CUBA to latest patch release


Have a nice Weekend!

Bye
Mario
